### PR TITLE
Installation fail fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ bs4
 HTMLparser
 argparse
 requests
-urlparse


### PR DESCRIPTION
urlparse is part of the standard Python 2 library